### PR TITLE
fix: update link in adding_languages.md

### DIFF
--- a/book/src/guides/adding_languages.md
+++ b/book/src/guides/adding_languages.md
@@ -16,7 +16,7 @@ below.
 
 > 💡 If you are adding a new Language Server configuration, make sure to update
 > the
-> [Language Server Wiki](https://github.com/helix-editor/helix/wiki/How-to-install-the-default-language-servers)
+> [Language Server Wiki](https://github.com/helix-editor/helix/wiki/Language-Server-Configurations)
 > with the installation instructions.
 
 ## Grammar configuration


### PR DESCRIPTION
Previously, the link would point to the now moved "How to install the default language servers" page. The link now directly points to the up-to-date page.